### PR TITLE
fixup! [HW4] Multi-thread TCP server

### DIFF
--- a/Homework4/Ex2/src/courses/courses.h
+++ b/Homework4/Ex2/src/courses/courses.h
@@ -27,8 +27,8 @@ void displayCourses(struct CourseList *courseList);
 void getStudentRegistrationList(struct RegistrationList *registrationList, char studentID[], struct CourseList* courseListByStudentID);
 void getCourseListByCourseIDAndWeekDay (struct CourseList *courseList, struct CourseList *courseListByStudentID, char weekday[]);
 void displayCourseList(struct CourseList *courseList);
-void displayCourseListByStudentIDAndWeekDay(struct RegistrationList *registrationList, struct CourseList *courseList, char studentID[], char weekday[]);
-void displayALLCoursesByStudentID(struct RegistrationList *registrationList, struct CourseList *courseList, char studentID[]);
+void displayCourseListByStudentIDAndWeekDay(struct RegistrationList *registrationList, struct CourseList *courseList, char studentID[], char weekday[], int connfd);
+void displayALLCoursesByStudentID(struct RegistrationList *registrationList, struct CourseList *courseList, char studentID[], int connfd);
 void freeCourseList(struct CourseList *courseList);
 
 #endif

--- a/Homework4/Ex2/src/server.c
+++ b/Homework4/Ex2/src/server.c
@@ -38,15 +38,15 @@ int login(char *studentID, char *username, char *password)
     }
 }
 
-void viewSchedule(char studentID[], char *weekday)
+void viewSchedule(char studentID[], char *weekday, int connfd)
 {
     if (!strcmp(weekday, "Monday") || !strcmp(weekday, "Tuesday") || !strcmp(weekday, "Wednesday") || !strcmp(weekday, "Thursday") || !strcmp(weekday, "Friday"))
     {
-        displayCourseListByStudentIDAndWeekDay(&registrationList, &courseList, studentID, weekday);
+        displayCourseListByStudentIDAndWeekDay(&registrationList, &courseList, studentID, weekday, connfd);
     }
     else if (strcmp(weekday, "ALL") == 0)
     {
-        displayALLCoursesByStudentID(&registrationList, &courseList, studentID);
+        displayALLCoursesByStudentID(&registrationList, &courseList, studentID, connfd);
     }
     else
         printf("Invalid weekday!!!\n\n");
@@ -143,13 +143,7 @@ int main(int argc, char **argv)
                     result = sscanf(buf, "%c %s", &cmd, weekday);
                     if (result == 2)
                     {
-                        viewSchedule(studentID, weekday);
-                        FILE *file = fopen("timetable.txt", "r"); // file receives the timetable.
-                        while ((n = fgets(sendline, MAXLINE, file)) != NULL)
-                        {
-                            n = send(connfd, sendline, strlen(sendline), 0);
-                        }
-                        fclose(file);
+                        viewSchedule(studentID, weekday, connfd);
                         usleep(500000);
                         n = send(connfd, END, strlen(END), 0);
                     }
@@ -160,13 +154,7 @@ int main(int argc, char **argv)
                     result = sscanf(buf, "%c %s", &cmd, weekday);
                     if (result == 2)
                     {
-                        viewSchedule(studentID, weekday);
-                        FILE *file = fopen("timetable.txt", "r"); // file receives the timetable.
-                        while ((n = fgets(sendline, MAXLINE, file)) != NULL)
-                        {
-                            n = send(connfd, sendline, strlen(sendline), 0);
-                        }
-                        fclose(file);
+                        viewSchedule(studentID, weekday, connfd);
                         usleep(500000);
                         n = send(connfd, END, strlen(END), 0);
                     }


### PR DESCRIPTION
Fix up synchronization error with multi-thread server.
Reason: The timetable is written a file, then server will send the content from this file (timetable.txt) to client => error when server serves for 2 different queries parallelly. 
Solution: send the content directly to client
[Demo for multithread server using signal.webm](https://github.com/liinhhnt/NetworkProgramming/assets/87489927/e20994d8-f288-4019-b511-762ff0bdb21d)
